### PR TITLE
jetson compose error fix

### DIFF
--- a/docker/compose.jetson.yml
+++ b/docker/compose.jetson.yml
@@ -15,7 +15,6 @@ services:
               count: 1
               capabilities: [gpu]
     environment:
-      - SSH_AUTH_SOCK=/ssh-agent
       - DISPLAY=${DISPLAY}
       - ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST
       - ROS_DOMAIN_ID=42
@@ -24,7 +23,6 @@ services:
       - ..:/f1tenth:cached
       - /dev:/dev
       - /tmp/.X11-unix:/tmp/.X11-unix
-      - $SSH_AUTH_SOCK:/ssh-agent
       - /usr/local/cuda:/usr/local/cuda
     tty: true
     stdin_open: true


### PR DESCRIPTION
just removed the ssh auth sock environment variable and volume mount from the compose-jetson.yaml file since it was causing it to error