### PR TITLE
fix annoying mypy import errors and clang-tidy header errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,6 +17,8 @@ Checks: "*,
         -readability-magic-numbers,
         -readability-identifier-length,
         -readability-function-cognitive-complexity
+        -misc-include-cleaner,
+        -misc-const-correctness
 "
 
 WarningsAsErrors: ''

--- a/.clangd
+++ b/.clangd
@@ -6,5 +6,6 @@ Index:
 
 Diagnostics:
   UnusedIncludes: None
+  MissingIncludes: None
   ClangTidy:
-    FastCheckFilter: Loose
+    FastCheckFilter: None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,4 @@ strict_equality = true
 strict_concatenate = true
 
 ignore_missing_imports = true
+follow_imports = "skip"


### PR DESCRIPTION
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it relates to an open issue, be sure to link to that issue. Ensure that you add a label to the PR describing the type of change (if the issue does not have one already for whatever reason).

we use a lot of third party python packages that have not implemented static typing, so mypy shits a brick when following imports. I just removed the check so we don't have to worry about static typing in anything but our own code.

Clangd on the vscode side of things skips some slow checks still (even with `FastCheckFilter: None` in the .clangd file), even if they aren't skipped in the .clang-tidy file. Had to remove the misc-const-correctness check because of this. The include cleaning check got removed from both clangd and clang-tidy since the ROS headers are so spread out we would have so many includes in our code. Not sure if this is okay practice but it's less annoying for new members if I remove it.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../docs/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any changes to main have been merged into my branch

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
